### PR TITLE
fix: JSONB slice fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Both generators handle all Go field types with optimized performance:
 - **Map Types**: `map[string]interface{}` with key-value copying
 - **Interface Types**: `interface{}` with reflection fallback
 - **JSON Types**: `datatypes.JSON`, custom JSON slices with Sonic performance
+- **JSONB Array Types**: `[]*Struct` with `gorm:"serializer:json"` tags (uses `reflect.DeepEqual`)
 - **Time Types**: `time.Time`, `*time.Time` with proper equality checking
 
 ## GORM Integration

--- a/examples/go-generate/models/clone.go
+++ b/examples/go-generate/models/clone.go
@@ -149,3 +149,40 @@ func (original *Service) Clone() *Service {
 
 	return &clone
 }
+
+// Clone creates a deep copy of the Tag struct
+func (original *Tag) Clone() *Tag {
+	if original == nil {
+		return nil
+	}
+	// Create new instance - all fields are simple types
+	clone := *original
+	return &clone
+}
+
+// Clone creates a deep copy of the Item struct
+func (original *Item) Clone() *Item {
+	if original == nil {
+		return nil
+	}
+	// Create new instance - all fields are simple types
+	clone := *original
+	return &clone
+}
+
+// Clone creates a deep copy of the SimpleModel struct
+func (original *SimpleModel) Clone() *SimpleModel {
+	if original == nil {
+		return nil
+	}
+	// Create new instance and copy all simple fields
+	clone := *original
+
+	// Only handle JSONB fields that need deep cloning
+
+	// TODO: Tags ([]*Tag) may need manual deep copy handling
+
+	// TODO: Items ([]*Item) may need manual deep copy handling
+
+	return &clone
+}

--- a/examples/go-generate/models/diff.go
+++ b/examples/go-generate/models/diff.go
@@ -941,3 +941,131 @@ func (new *Service) Diff(old *Service) map[string]interface{} {
 
 	return diff
 }
+
+// Diff compares this Tag instance (new) with another (old) and returns a map of differences
+// with only the new values for fields that have changed.
+// Usage: newValues = new.Diff(old)
+// Returns nil if either pointer is nil.
+func (new *Tag) Diff(old *Tag) map[string]interface{} {
+	// Handle nil pointers
+	if new == nil || old == nil {
+		return nil
+	}
+
+	diff := make(map[string]interface{})
+
+	// Compare Name
+
+	// Simple type comparison
+	if new.Name != old.Name {
+		diff["name"] = new.Name
+	}
+
+	// Compare Value
+
+	// Simple type comparison
+	if new.Value != old.Value {
+		diff["value"] = new.Value
+	}
+
+	return diff
+}
+
+// Diff compares this Item instance (new) with another (old) and returns a map of differences
+// with only the new values for fields that have changed.
+// Usage: newValues = new.Diff(old)
+// Returns nil if either pointer is nil.
+func (new *Item) Diff(old *Item) map[string]interface{} {
+	// Handle nil pointers
+	if new == nil || old == nil {
+		return nil
+	}
+
+	diff := make(map[string]interface{})
+
+	// Compare ID
+
+	// Simple type comparison
+	if new.ID != old.ID {
+		diff["id"] = new.ID
+	}
+
+	// Compare Title
+
+	// Simple type comparison
+	if new.Title != old.Title {
+		diff["title"] = new.Title
+	}
+
+	// Compare Price
+
+	// Simple type comparison
+	if new.Price != old.Price {
+		diff["price"] = new.Price
+	}
+
+	return diff
+}
+
+// Diff compares this SimpleModel instance (new) with another (old) and returns a map of differences
+// with only the new values for fields that have changed.
+// Usage: newValues = new.Diff(old)
+// Returns nil if either pointer is nil.
+func (new *SimpleModel) Diff(old *SimpleModel) map[string]interface{} {
+	// Handle nil pointers
+	if new == nil || old == nil {
+		return nil
+	}
+
+	diff := make(map[string]interface{})
+
+	// Compare ID
+
+	// UUID comparison
+
+	// Direct UUID comparison
+	if new.ID != old.ID {
+		diff["ID"] = new.ID
+	}
+
+	// Compare Name
+
+	// Simple type comparison
+	if new.Name != old.Name {
+		diff["Name"] = new.Name
+	}
+
+	// Compare Tags
+
+	// JSON field comparison - handle both datatypes.JSON and struct types with jsonb storage
+
+	// JSON field comparison - custom slice types with jsonb storage (not comparable with !=)
+	if !reflect.DeepEqual(new.Tags, old.Tags) {
+		jsonValue, err := sonic.Marshal(new.Tags)
+		if err == nil && !isEmptyJSON(string(jsonValue)) {
+			diff["Tags"] = gorm.Expr("? || ?", clause.Column{Name: "tags"}, string(jsonValue))
+		} else if err != nil {
+			// Fallback to regular assignment if JSON marshaling fails
+			diff["Tags"] = new.Tags
+		}
+		// Skip adding to diff if JSON is empty (no-op update)
+	}
+
+	// Compare Items
+
+	// JSON field comparison - handle both datatypes.JSON and struct types with jsonb storage
+
+	// JSON field comparison - custom slice types with jsonb storage (not comparable with !=)
+	if !reflect.DeepEqual(new.Items, old.Items) {
+		jsonValue, err := sonic.Marshal(new.Items)
+		if err == nil && !isEmptyJSON(string(jsonValue)) {
+			diff["Items"] = gorm.Expr("? || ?", clause.Column{Name: "items"}, string(jsonValue))
+		} else if err != nil {
+			// Fallback to regular assignment if JSON marshaling fails
+			diff["Items"] = new.Items
+		}
+		// Skip adding to diff if JSON is empty (no-op update)
+	}
+
+	return diff
+}

--- a/examples/go-generate/models/simple_model.go
+++ b/examples/go-generate/models/simple_model.go
@@ -1,0 +1,32 @@
+package models
+
+import (
+	"github.com/google/uuid"
+)
+
+// Tag represents a simple tag for testing array of objects
+// @jsonb
+type Tag struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// Item represents an item for testing array of objects  
+// @jsonb
+type Item struct {
+	ID    int     `json:"id"`
+	Title string  `json:"title"`
+	Price float64 `json:"price,omitempty"`
+}
+
+// SimpleModel demonstrates JSONB array fields issue
+type SimpleModel struct {
+	ID    uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	Name  string    `gorm:"type:string;not null" json:"name"`
+	Tags  []*Tag    `gorm:"type:jsonb;serializer:json;default:'[]'" json:"tags,omitempty"`
+	Items []*Item   `gorm:"type:jsonb;serializer:json;default:'[]'" json:"items,omitempty"`
+}
+
+func (SimpleModel) TableName() string {
+	return "simple_models"
+}

--- a/pkg/diffgen/templates/diff_function.tmpl
+++ b/pkg/diffgen/templates/diff_function.tmpl
@@ -49,8 +49,20 @@ func (new *{{.Name}}) Diff(old *{{.Name}}) map[string]interface{} {
 		}
 		// Skip adding to diff if JSON is empty (no-op update)
 	}
-	{{else if or (hasPrefix .Type "JsonbStringSlice") (hasSuffix .Type "Slice")}}
+	{{else if or (hasPrefix .Type "JsonbStringSlice") (hasSuffix .Type "Slice") (hasPrefix .Type "[]")}}
 	// JSON field comparison - custom slice types with jsonb storage (not comparable with !=)
+	if !reflect.DeepEqual(new.{{.Name}}, old.{{.Name}}) {
+		jsonValue, err := sonic.Marshal(new.{{.Name}})
+		if err == nil && !isEmptyJSON(string(jsonValue)) {
+			diff["{{.DiffKey}}"] = gorm.Expr("? || ?", clause.Column{Name: "{{getColumnName .Name .Tag}}"}, string(jsonValue))
+		} else if err != nil {
+			// Fallback to regular assignment if JSON marshaling fails
+			diff["{{.DiffKey}}"] = new.{{.Name}}
+		}
+		// Skip adding to diff if JSON is empty (no-op update)
+	}
+	{{else if hasPrefix .Type "[]"}}
+	// JSON field comparison - slice types with jsonb storage (use reflect.DeepEqual)
 	if !reflect.DeepEqual(new.{{.Name}}, old.{{.Name}}) {
 		jsonValue, err := sonic.Marshal(new.{{.Name}})
 		if err == nil && !isEmptyJSON(string(jsonValue)) {


### PR DESCRIPTION
fix: support JSONB array fields in diff template

Fix slice detection in diff template to use reflect.DeepEqual for 
[]*Struct fields with gorm:"serializer:json" tags instead of trying 
to call non-existent Diff() method on slices.

Fixes go generate errors on models with JSONB array fields.